### PR TITLE
chore: remove hardcoded database URL from Alembic config

### DIFF
--- a/backend/fastapi/alembic.ini
+++ b/backend/fastapi/alembic.ini
@@ -1,6 +1,6 @@
 [alembic]
 script_location = alembic
-sqlalchemy.url = postgresql+psycopg://arirang_user:arirang_password@localhost:5433/arirang
+sqlalchemy.url = driver://user:pass@localhost/dbname
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/fastapi/database.py
+++ b/backend/fastapi/database.py
@@ -8,10 +8,10 @@ from sqlalchemy.orm import declarative_base, sessionmaker
 BASE_DIR = Path(__file__).resolve().parent
 load_dotenv(BASE_DIR / ".env")
 
-DATABASE_URL = os.getenv(
-    "DATABASE_URL",
-    "postgresql+psycopg://arirang_user:arirang_password@localhost:5433/arirang",
-)
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if DATABASE_URL is None:
+    raise RuntimeError("DATABASE_URL 환경변수가 설정되어 있지 않습니다.")
 
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)


### PR DESCRIPTION
## 작업 내역
- [x] `alembic.ini`에 노출되어 있던 DB 연결 문자열 제거
- [x] Alembic 실행 시 `env.py`에서 `DATABASE_URL` 환경변수를 사용하도록 수정
- [x] 실제 DB 연결 정보는 `.env`에서만 관리하도록 정리

## 관련된 이슈
- resolves #

## 리뷰어에게 할 말
- 기존 PR이 merge된 이후 보안 리뷰 반영 커밋이 추가되어 별도 PR로 올립니다.

## 체크리스트
- [x] 코드가 정상적으로 빌드 및 실행됨.
- [x] 민감한 환경변수(API 키 등)가 코드에 포함되지 않음.