### PR TITLE
feat: add sentence relation and tts url to quiz schema

### DIFF
--- a/backend/fastapi/alembic/versions/7b8c2d4f1a90_add_tts_urls.py
+++ b/backend/fastapi/alembic/versions/7b8c2d4f1a90_add_tts_urls.py
@@ -1,0 +1,42 @@
+"""add tts urls and quiz sentence link
+
+Revision ID: 7b8c2d4f1a90
+Revises: 42116df0ca1f
+Create Date: 2026-05-12 00:00:00
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "7b8c2d4f1a90"
+down_revision = "42116df0ca1f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("sentences", sa.Column("tts_url", sa.String(), nullable=True))
+    op.add_column("quizzes", sa.Column("sentence_id", sa.String(), nullable=True))
+    op.add_column("quizzes", sa.Column("tts_url", sa.String(), nullable=True))
+    op.create_index(
+        op.f("ix_quizzes_sentence_id"),
+        "quizzes",
+        ["sentence_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "fk_quizzes_sentence_id_sentences",
+        "quizzes",
+        "sentences",
+        ["sentence_id"],
+        ["sentence_id"],
+    )
+
+
+def downgrade():
+    op.drop_constraint("fk_quizzes_sentence_id_sentences", "quizzes", type_="foreignkey")
+    op.drop_index(op.f("ix_quizzes_sentence_id"), table_name="quizzes")
+    op.drop_column("quizzes", "tts_url")
+    op.drop_column("quizzes", "sentence_id")
+    op.drop_column("sentences", "tts_url")

--- a/backend/fastapi/db_models.py
+++ b/backend/fastapi/db_models.py
@@ -55,20 +55,26 @@ class SentenceDB(Base):
     )
     content = Column(Text, nullable=False)
     highlight = Column(String, nullable=True)
+    tts_url = Column(String, nullable=True)
 
     meaning = relationship("MeaningDB", back_populates="sentences")
+    quizzes = relationship("QuizDB", back_populates="sentence")
 
 
 class QuizDB(Base):
     __tablename__ = "quizzes"
 
     card_id = Column(String, primary_key=True, index=True)
+    sentence_id = Column(
+        String, ForeignKey("sentences.sentence_id"), nullable=True, index=True
+    )
     meaning_id = Column(
         String, ForeignKey("meanings.meaning_id"), nullable=False, index=True
     )
     polysemy_word = Column(String, nullable=False)
     prompt_sentence = Column(Text, nullable=False)
     pronunciation_target = Column(String, nullable=True)
+    tts_url = Column(String, nullable=True)
     image_url = Column(String, nullable=True)
     card_order = Column(Integer, nullable=False)
     set_id = Column(
@@ -76,6 +82,7 @@ class QuizDB(Base):
     )
 
     meaning = relationship("MeaningDB", back_populates="quizzes")
+    sentence = relationship("SentenceDB", back_populates="quizzes")
     learning_set = relationship("LearningSetDB", back_populates="quizzes")
     choices = relationship(
         "QuizChoiceDB", back_populates="quiz", cascade="all, delete-orphan"

--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -36,6 +36,7 @@ from schemas import (
     SetCardsData,
     SetCardsResponse,
     AnswerSubmitRequest,
+    TtsUrlUpdateRequest,
     AnswerResult,
     AnswerSubmitResponse,
     PronunciationResult,
@@ -45,7 +46,7 @@ from schemas import (
 )
 
 from database import get_db
-from db_models import CategoryDB, LearningSetDB, QuizDB, QuizChoiceDB
+from db_models import CategoryDB, LearningSetDB, QuizDB, QuizChoiceDB, SentenceDB
 
 # =============================================================================
 # FastAPI 앱 초기화
@@ -157,10 +158,12 @@ def get_cards_for_set(db: Session, set_id: str):
         cards.append(
             LearningCard(
                 card_id=quiz.card_id,
+                sentence_id=quiz.sentence_id,
                 polysemy_word=quiz.polysemy_word,
                 prompt_sentence=quiz.prompt_sentence,
                 choices=choices,
                 pronunciation_target=quiz.pronunciation_target,
+                tts_url=quiz.tts_url,
                 image_url=quiz.image_url,
                 card_order=quiz.card_order,
             )
@@ -355,7 +358,57 @@ async def get_set_cards(set_id: str, db: Session = Depends(get_db)):
 
 
 # =============================================================================
-# 6. 의미 테스트 답안 제출
+# 6. TTS URL 갱신
+# =============================================================================
+
+
+@app.patch("/api/v1/sentences/{sentence_id}/tts-url")
+async def update_sentence_tts_url(
+    sentence_id: str,
+    request: TtsUrlUpdateRequest,
+    db: Session = Depends(get_db),
+):
+    """
+    문장 TTS URL 갱신 API
+
+    AI가 TTS 파일을 Object Storage에 업로드한 뒤 받은 URL을 전달하면,
+    문장과 해당 문장을 프롬프트로 사용하는 카드에 URL을 저장합니다.
+    """
+
+    sentence = (
+        db.query(SentenceDB).filter(SentenceDB.sentence_id == sentence_id).one_or_none()
+    )
+    if sentence is None:
+        return {
+            "success": False,
+            "data": None,
+            "message": "존재하지 않는 문장입니다.",
+        }
+
+    sentence.tts_url = request.tts_url
+    updated_cards = (
+        db.query(QuizDB)
+        .filter(QuizDB.sentence_id == sentence_id)
+        .all()
+    )
+    for quiz in updated_cards:
+        quiz.tts_url = request.tts_url
+
+    db.commit()
+
+    return {
+        "success": True,
+        "data": {
+            "sentence_id": sentence_id,
+            "tts_url": request.tts_url,
+            "updated_card_count": len(updated_cards),
+        },
+        "message": None,
+    }
+
+
+# =============================================================================
+# 7. 의미 테스트 답안 제출
 # =============================================================================
 
 
@@ -421,7 +474,7 @@ async def submit_card_answer(
 
 
 # =============================================================================
-# 7. 발음 평가 요청
+# 8. 발음 평가 요청
 # =============================================================================
 
 
@@ -430,6 +483,7 @@ async def evaluate_pronunciation(
     card_id: str,
     target_text: str = Form(...),
     audio_file: UploadFile = File(...),
+    db: Session = Depends(get_db),
 ):
     """
     발음 평가 요청 API
@@ -440,9 +494,8 @@ async def evaluate_pronunciation(
     현재는 실제 음성 분석 모델 없이 고정 더미 결과를 반환합니다. (추후 AI 모델 연동 예정)
     """
 
-    allowed_card_ids = {f"card_{i:03d}" for i in range(1, 36)}
-
-    if card_id not in allowed_card_ids:
+    quiz = db.query(QuizDB).filter(QuizDB.card_id == card_id).one_or_none()
+    if quiz is None:
         return PronunciationResponse(
             success=False,
             data=None,
@@ -472,7 +525,7 @@ async def evaluate_pronunciation(
 
 
 # =============================================================================
-# 8. 저장 단어 목록 조회
+# 9. 저장 단어 목록 조회
 # =============================================================================
 
 

--- a/backend/fastapi/schemas.py
+++ b/backend/fastapi/schemas.py
@@ -104,11 +104,13 @@ class LearningCard(BaseModel):
     """
 
     card_id: str
+    sentence_id: Optional[str] = None
     polysemy_word: str
     prompt_sentence: str
     choices: List[Choice]
     pronunciation_target: str
-    image_url: str
+    tts_url: Optional[str] = None
+    image_url: Optional[str] = None
     card_order: int
 
 
@@ -138,6 +140,14 @@ class AnswerSubmitRequest(BaseModel):
     """
 
     choice_id: str
+
+
+class TtsUrlUpdateRequest(BaseModel):
+    """
+    TTS URL 갱신 Request 모델
+    """
+
+    tts_url: str
 
 
 class AnswerResult(BaseModel):

--- a/backend/fastapi/seed.py
+++ b/backend/fastapi/seed.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from collections import defaultdict
 
 from database import Base, SessionLocal, engine
 from db_models import (
@@ -56,6 +57,16 @@ SET_THUMBNAIL_MAPPING = {
     "set_pc_game_01": "/assets/cards/placeholder.png",
     "set_university_01": "/assets/cards/placeholder.png",
     "set_test_01": "/assets/cards/placeholder.png",
+}
+
+WORD_TO_SET = {
+    "쓰다": "set_school_01",
+    "눈": "set_test_01",
+}
+
+WORD_IMAGE_MAPPING = {
+    "쓰다": "/assets/cards/bird-write.png",
+    "눈": "/assets/cards/placeholder.png",
 }
 
 
@@ -135,11 +146,119 @@ def seed_sentences(session, sentences):
                     meaning_id=item.get("meaning_id", ""),
                     content=item.get("content", ""),
                     highlight=item.get("highlight", ""),
+                    tts_url=item.get("tts_url"),
                 )
             )
+        else:
+            sentence.meaning_id = item.get("meaning_id", sentence.meaning_id)
+            sentence.content = item.get("content", sentence.content)
+            sentence.highlight = item.get("highlight", sentence.highlight)
+            if item.get("tts_url"):
+                sentence.tts_url = item.get("tts_url")
+
+
+def build_quizzes_from_sentences(meanings, sentences, quiz_overrides):
+    meanings_by_id = {item.get("id"): item for item in meanings if item.get("id")}
+    sentences_by_meaning = defaultdict(list)
+    meanings_by_word = defaultdict(list)
+    overrides_by_meaning = {}
+    overrides_by_card_id = {}
+    overrides_by_prompt = {}
+
+    for meaning in meanings_by_id.values():
+        meanings_by_word[meaning.get("word", "")].append(meaning)
+
+    for sentence in sentences:
+        meaning_id = sentence.get("meaning_id")
+        if meaning_id in meanings_by_id:
+            sentences_by_meaning[meaning_id].append(sentence)
+
+    for item in quiz_overrides:
+        if item.get("meaning_id") and item.get("meaning_id") not in overrides_by_meaning:
+            overrides_by_meaning[item["meaning_id"]] = item
+        if item.get("card_id"):
+            overrides_by_card_id[item["card_id"]] = item
+        if item.get("meaning_id") and item.get("prompt_sentence"):
+            overrides_by_prompt[(item["meaning_id"], item["prompt_sentence"])] = item
+
+    generated = []
+    card_order_by_set = defaultdict(int)
+
+    for prompt in sentences:
+        prompt_id = prompt.get("id")
+        meaning_id = prompt.get("meaning_id")
+        meaning = meanings_by_id.get(meaning_id)
+        if not prompt_id or not meaning:
+            continue
+
+        word = meaning.get("word", "")
+        correct_pool = [
+            sentence
+            for sentence in sentences_by_meaning[meaning_id]
+            if sentence.get("id") != prompt_id
+        ]
+        if not correct_pool:
+            continue
+
+        distractors = []
+        for other_meaning in meanings_by_word[word]:
+            other_meaning_id = other_meaning.get("id")
+            if other_meaning_id == meaning_id:
+                continue
+            other_sentences = sentences_by_meaning.get(other_meaning_id, [])
+            if other_sentences:
+                distractors.append(other_sentences[0])
+
+        if len(distractors) < 3:
+            continue
+
+        prompt_override = overrides_by_prompt.get((meaning_id, prompt.get("content", "")), {})
+        card_id = prompt_override.get("card_id") or f"card_{prompt_id}"
+        meaning_override = overrides_by_meaning.get(meaning_id, {})
+        card_override = overrides_by_card_id.get(card_id, {})
+        override = {**meaning_override, **prompt_override, **card_override}
+        set_id = override.get("set_id") or WORD_TO_SET.get(word, "set_test_01")
+
+        card_order_by_set[set_id] += 1
+        choices = [correct_pool[0], *distractors[:3]]
+
+        generated.append(
+            {
+                "card_id": card_id,
+                "sentence_id": prompt_id,
+                "meaning_id": meaning_id,
+                "polysemy_word": word,
+                "prompt_sentence": prompt.get("content", ""),
+                "choices": [
+                    {
+                        "choice_id": f"c{index}",
+                        "text": choice.get("content", ""),
+                        "meaning_id": choice.get("meaning_id", ""),
+                    }
+                    for index, choice in enumerate(choices, start=1)
+                ],
+                "correct_choice_id": "c1",
+                "pronunciation_target": prompt.get("highlight", "") or word,
+                "tts_url": override.get("tts_url") or prompt.get("tts_url"),
+                "image_url": override.get("image_url")
+                or WORD_IMAGE_MAPPING.get(word, "/assets/cards/placeholder.png"),
+                "card_order": card_order_by_set[set_id],
+                "set_id": set_id,
+            }
+        )
+
+    return generated
 
 
 def seed_quizzes(session, quizzes):
+    desired_card_ids = {item.get("card_id") for item in quizzes if item.get("card_id")}
+    if desired_card_ids:
+        existing_quizzes = session.query(QuizDB).all()
+        for quiz in existing_quizzes:
+            if quiz.card_id not in desired_card_ids:
+                session.delete(quiz)
+        session.flush()
+
     for item in quizzes:
         card_id = item.get("card_id")
         if not card_id:
@@ -149,15 +268,30 @@ def seed_quizzes(session, quizzes):
         if quiz is None:
             quiz = QuizDB(
                 card_id=card_id,
+                sentence_id=item.get("sentence_id"),
                 meaning_id=item.get("meaning_id", ""),
                 polysemy_word=item.get("polysemy_word", ""),
                 prompt_sentence=item.get("prompt_sentence", ""),
                 pronunciation_target=item.get("pronunciation_target", ""),
+                tts_url=item.get("tts_url"),
                 image_url=item.get("image_url", ""),
                 card_order=item.get("card_order", 0),
                 set_id=item.get("set_id", ""),
             )
             session.add(quiz)
+        else:
+            quiz.sentence_id = item.get("sentence_id", quiz.sentence_id)
+            quiz.meaning_id = item.get("meaning_id", quiz.meaning_id)
+            quiz.polysemy_word = item.get("polysemy_word", quiz.polysemy_word)
+            quiz.prompt_sentence = item.get("prompt_sentence", quiz.prompt_sentence)
+            quiz.pronunciation_target = item.get(
+                "pronunciation_target", quiz.pronunciation_target
+            )
+            if item.get("tts_url"):
+                quiz.tts_url = item.get("tts_url")
+            quiz.image_url = item.get("image_url", quiz.image_url)
+            quiz.card_order = item.get("card_order", quiz.card_order)
+            quiz.set_id = item.get("set_id", quiz.set_id)
 
         for choice_data in item.get("choices", []):
             choice_id = choice_data.get("choice_id")
@@ -178,6 +312,12 @@ def seed_quizzes(session, quizzes):
                         is_correct=choice_id == item.get("correct_choice_id"),
                     )
                 )
+            else:
+                existing_choice.text = choice_data.get("text", existing_choice.text)
+                existing_choice.meaning_id = choice_data.get(
+                    "meaning_id", existing_choice.meaning_id
+                )
+                existing_choice.is_correct = choice_id == item.get("correct_choice_id")
 
 
 def main():
@@ -185,7 +325,8 @@ def main():
     words = load_json("words.json")
     meanings = load_json("meanings.json")
     sentences = load_json("sentences.json")
-    quizzes = load_json("quizzes.json")
+    quiz_overrides = load_json("quizzes.json")
+    quizzes = build_quizzes_from_sentences(meanings, sentences, quiz_overrides)
 
     with SessionLocal() as session:
         seed_categories(session)

--- a/content_data/src/models.py
+++ b/content_data/src/models.py
@@ -1,7 +1,7 @@
 import json
 import os
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel, Field
 
 from src.utils.logger import logger
@@ -70,6 +70,7 @@ class Sentence(BaseModel):
     meaning_id: str
     content: str
     highlight: str
+    tts_url: Optional[str] = None
 
 
 class QuizChoice(BaseModel):
@@ -86,6 +87,7 @@ class Quiz(BaseModel):
     choices: List[QuizChoice]
     correct_choice_id: str
     pronunciation_target: str
+    tts_url: Optional[str] = None
     image_url: str
     card_order: int
     set_id: str

--- a/docs/backend-db-erd-updated.svg
+++ b/docs/backend-db-erd-updated.svg
@@ -1,0 +1,178 @@
+<svg width="1600" height="1100" viewBox="0 0 1600 1100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .bg { fill: #f8fbff; }
+      .title { font: 700 50px Arial, sans-serif; fill: #0f172a; }
+      .subtitle { font: 700 32px Arial, sans-serif; fill: #174a86; }
+      .caption { font: 600 24px Arial, sans-serif; fill: #4b5563; }
+      .table { fill: #ffffff; stroke: #0b2f66; stroke-width: 2.4; }
+      .head { fill: #eef6ff; stroke: #0b2f66; stroke-width: 2.4; }
+      .name { font: 700 23px Arial, sans-serif; fill: #10254a; }
+      .cell { font: 600 19px Arial, sans-serif; fill: #111827; }
+      .muted { font: 400 16px Arial, sans-serif; fill: #374151; font-style: italic; }
+      .pkfk { font: 700 18px Arial, sans-serif; fill: #1d4ed8; }
+      .noteTitle { font: 700 28px Arial, sans-serif; }
+      .note { font: 600 20px Arial, sans-serif; fill: #111827; }
+      .tiny { font: 600 17px Arial, sans-serif; fill: #111827; }
+      .line { stroke: #111827; stroke-width: 2.8; fill: none; }
+      .dash { stroke: #0b2f66; stroke-width: 2.2; stroke-dasharray: 8 7; fill: none; }
+    </style>
+    <marker id="crow" markerWidth="18" markerHeight="18" refX="16" refY="9" orient="auto">
+      <path d="M1,1 L16,9 L1,17 M16,9 L1,9" stroke="#111827" stroke-width="2" fill="none"/>
+    </marker>
+    <marker id="one" markerWidth="12" markerHeight="12" refX="11" refY="6" orient="auto">
+      <path d="M10,1 L10,11" stroke="#111827" stroke-width="2"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="1600" height="1100"/>
+  <text class="title" x="800" y="65" text-anchor="middle">Arirang-Soorirang Backend DB ERD</text>
+  <text class="subtitle" x="800" y="112" text-anchor="middle">PostgreSQL + SQLAlchemy + Alembic</text>
+  <text class="caption" x="800" y="152" text-anchor="middle">Updated: sentences.json 기반 문제 생성 + TTS URL 저장/응답</text>
+
+  <!-- categories -->
+  <g transform="translate(40,185)">
+    <rect class="table" width="260" height="205" rx="8"/>
+    <rect class="head" width="260" height="52" rx="8"/>
+    <text class="name" x="130" y="34" text-anchor="middle">categories</text>
+    <line class="line" x1="0" y1="52" x2="260" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="205"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">category_id</text>
+    <text class="cell" x="86" y="135">name_ko</text>
+    <text class="cell" x="86" y="175">name_en</text>
+  </g>
+
+  <!-- learning_sets -->
+  <g transform="translate(385,185)">
+    <rect class="table" width="310" height="250" rx="8"/>
+    <rect class="head" width="310" height="52" rx="8"/>
+    <text class="name" x="155" y="34" text-anchor="middle">learning_sets</text>
+    <line class="line" x1="0" y1="52" x2="310" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="250"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">set_id</text>
+    <text class="cell" x="86" y="132">title</text>
+    <text class="pkfk" x="34" y="174" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="174">category_id</text>
+    <text class="muted" x="86" y="200">(FK → categories.category_id)</text>
+    <text class="cell" x="86" y="232">thumbnail_url</text>
+  </g>
+
+  <!-- quizzes -->
+  <g transform="translate(830,185)">
+    <rect class="table" width="380" height="430" rx="8"/>
+    <rect class="head" width="380" height="52" rx="8"/>
+    <text class="name" x="190" y="34" text-anchor="middle">quizzes</text>
+    <line class="line" x1="0" y1="52" x2="380" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="430"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">card_id</text>
+    <text class="pkfk" x="34" y="132" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="132">sentence_id</text>
+    <text class="muted" x="86" y="156">(FK → sentences.sentence_id)</text>
+    <text class="pkfk" x="34" y="195" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="195">meaning_id</text>
+    <text class="muted" x="86" y="219">(FK → meanings.meaning_id)</text>
+    <text class="cell" x="86" y="252">polysemy_word</text>
+    <text class="cell" x="86" y="282">prompt_sentence</text>
+    <text class="cell" x="86" y="312">pronunciation_target</text>
+    <text class="cell" x="86" y="342">tts_url</text>
+    <text class="muted" x="86" y="366">(Object Storage URL)</text>
+    <text class="cell" x="86" y="396">image_url</text>
+    <text class="pkfk" x="34" y="420" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="420">card_order / set_id</text>
+  </g>
+
+  <!-- quiz_choices -->
+  <g transform="translate(1295,185)">
+    <rect class="table" width="255" height="330" rx="8"/>
+    <rect class="head" width="255" height="52" rx="8"/>
+    <text class="name" x="128" y="34" text-anchor="middle">quiz_choices</text>
+    <line class="line" x1="0" y1="52" x2="255" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="330"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">id</text>
+    <text class="muted" x="86" y="116">(autoincrement)</text>
+    <text class="pkfk" x="34" y="158" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="158">card_id</text>
+    <text class="muted" x="86" y="184">(FK → quizzes.card_id)</text>
+    <text class="cell" x="86" y="222">choice_id</text>
+    <text class="cell" x="86" y="252">text</text>
+    <text class="cell" x="86" y="282">meaning_id</text>
+    <text class="cell" x="86" y="312">is_correct</text>
+  </g>
+
+  <!-- words -->
+  <g transform="translate(55,575)">
+    <rect class="table" width="275" height="185" rx="8"/>
+    <rect class="head" width="275" height="52" rx="8"/>
+    <text class="name" x="138" y="34" text-anchor="middle">words</text>
+    <line class="line" x1="0" y1="52" x2="275" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="185"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">id</text>
+    <text class="muted" x="86" y="116">(autoincrement)</text>
+    <text class="cell" x="86" y="150">word</text>
+    <text class="muted" x="86" y="174">(UNIQUE)</text>
+  </g>
+
+  <!-- meanings -->
+  <g transform="translate(505,650)">
+    <rect class="table" width="275" height="200" rx="8"/>
+    <rect class="head" width="275" height="52" rx="8"/>
+    <text class="name" x="138" y="34" text-anchor="middle">meanings</text>
+    <line class="line" x1="0" y1="52" x2="275" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="200"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">meaning_id</text>
+    <text class="cell" x="86" y="138">word</text>
+    <text class="cell" x="86" y="178">definition</text>
+  </g>
+
+  <!-- sentences -->
+  <g transform="translate(1170,650)">
+    <rect class="table" width="350" height="260" rx="8"/>
+    <rect class="head" width="350" height="52" rx="8"/>
+    <text class="name" x="175" y="34" text-anchor="middle">sentences</text>
+    <line class="line" x1="0" y1="52" x2="350" y2="52"/>
+    <line class="line" x1="68" y1="52" x2="68" y2="260"/>
+    <text class="pkfk" x="34" y="90" text-anchor="middle">PK</text>
+    <text class="cell" x="86" y="90">sentence_id</text>
+    <text class="pkfk" x="34" y="132" text-anchor="middle">FK</text>
+    <text class="cell" x="86" y="132">meaning_id</text>
+    <text class="muted" x="86" y="158">(FK → meanings.meaning_id)</text>
+    <text class="cell" x="86" y="198">content</text>
+    <text class="cell" x="86" y="228">highlight</text>
+    <text class="cell" x="86" y="252">tts_url</text>
+  </g>
+
+  <!-- relationships -->
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M300 288 C335 288 350 310 385 310"/>
+  <text class="tiny" x="315" y="270">1</text><text class="tiny" x="358" y="337">N</text>
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M695 310 C745 310 770 352 830 352"/>
+  <text class="tiny" x="712" y="290">1</text><text class="tiny" x="800" y="380">N</text>
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M1210 310 C1245 310 1260 350 1295 350"/>
+  <text class="tiny" x="1225" y="292">1</text><text class="tiny" x="1268" y="378">N</text>
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M780 742 C945 742 980 778 1170 778"/>
+  <text class="tiny" x="800" y="720">1</text><text class="tiny" x="1138" y="805">N</text>
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M780 690 C805 650 815 545 830 545"/>
+  <text class="tiny" x="792" y="668">1</text><text class="tiny" x="805" y="573">N</text>
+  <path class="line" marker-start="url(#one)" marker-end="url(#crow)" d="M1345 650 C1345 610 1020 655 1020 615"/>
+  <text class="tiny" x="1358" y="638">1</text><text class="tiny" x="1030" y="640">N</text>
+
+  <!-- notes -->
+  <rect x="40" y="800" width="380" height="100" rx="14" fill="#ffffff" stroke="#0b2f66" stroke-width="2" stroke-dasharray="8 7"/>
+  <text class="note" x="72" y="845">words는 standalone 테이블이며,</text>
+  <text class="note" x="72" y="875">meanings와 직접 FK 관계가 없습니다.</text>
+
+  <rect x="25" y="945" width="720" height="120" rx="12" fill="#f0fdf4" stroke="#15803d" stroke-width="2"/>
+  <text class="noteTitle" x="150" y="997" fill="#166534">Seed source</text>
+  <text class="note" x="150" y="1040">words.json, meanings.json, sentences.json</text>
+  <text class="tiny" x="150" y="1063">quizzes.json은 image_url / set_id / tts_url / legacy card_id override 용도</text>
+
+  <rect x="800" y="945" width="760" height="120" rx="12" fill="#fff7ed" stroke="#c2410c" stroke-width="2"/>
+  <text class="noteTitle" x="940" y="997" fill="#c2410c">TTS update API</text>
+  <text class="note" x="940" y="1040">PATCH /api/v1/sentences/{sentence_id}/tts-url</text>
+  <text class="tiny" x="940" y="1063">AI → Object Storage 업로드 → URL을 백엔드에 전달 → sentences/quizzes 반영</text>
+</svg>


### PR DESCRIPTION

## 작업 내역
- [x] `sentences.json` + `meanings.json` 기반으로 퀴즈를 생성하도록 `seed.py` 로직 수정
- [x] `quizzes.sentence_id` 컬럼 추가 및 `sentences.sentence_id` FK 관계 연결
- [x] `sentences.tts_url`, `quizzes.tts_url` 컬럼 추가
- [x] 카드 조회 API 응답에 `sentence_id`, `tts_url` 포함
- [x] AI 팀이 Object Storage 업로드 후 TTS URL을 전달할 수 있도록 `PATCH /api/v1/sentences/{sentence_id}/tts-url` API 추가
- [x] 기존 `card_001` 기반 API 테스트가 깨지지 않도록 `quizzes.json`의 기존 `card_id` override 유지
- [x] 수정된 DB 구조를 반영한 ERD SVG 문서 추가

## 관련된 이슈
- resolves #

## ERD
<img width="1448" height="1086" alt="image" src="https://github.com/user-attachments/assets/6d9582a5-8b0e-4c25-a1f1-5d5148de3edc" />


## 리뷰어에게 할 말 (선택)
- 기존에는 `quizzes.json`을 그대로 seed했지만, 이제는 `sentences.json`을 문제 pool로 사용합니다.
- `quizzes.json`은 완전히 제거하지 않고 `image_url`, `set_id`, `tts_url`, 기존 `card_id` override 용도로 유지했습니다.
- TTS 연동 흐름은 `AI → Object Storage 업로드 → 백엔드에 URL 전달 → sentences/quizzes에 반영` 구조입니다.
- 테스트 중 기존 `POST /api/v1/cards/card_001/answer` 호환성을 위해 `card_001`이 유지되도록 보강했습니다.

## 테스트 내용
- [x] `docker compose down -v`
- [x] `docker compose up -d`
- [x] `cd backend/fastapi`
- [x] `.venv/bin/alembic upgrade head`
- [x] `.venv/bin/python seed.py`
- [x] `.venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port 8000`
- [x] `GET /api/v1/contents/recommended` 정상 응답 확인
- [x] `GET /api/v1/categories` 정상 응답 확인
- [x] `GET /api/v1/categories/school/sets` 정상 응답 확인
- [x] `GET /api/v1/sets/set_school_01/cards` 정상 응답 확인
- [x] `POST /api/v1/cards/card_001/answer` 정상 응답 확인
- [x] `PATCH /api/v1/sentences/3c9979ce/tts-url` 정상 반영 확인
- [x] DB에서 `sentences.tts_url`, `quizzes.tts_url`, `quizzes.sentence_id` 저장 확인

## 체크리스트
- [x] 코드가 정상적으로 빌드 및 실행됨.
- [x] 불필요한 `console.log`나 주석을 제거함.
- [x] 민감한 환경변수(API 키 등)가 코드에 포함되지 않음.
