### PR TITLE
프론트엔드와 백엔드 Docker 배포 구성 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
-# PostgreSQL Database Configuration
+# Copy this file to .env and replace the values before running docker compose.
 POSTGRES_DB=arirang
-POSTGRES_USER=arirang_user
-POSTGRES_PASSWORD=change_me
-DATABASE_URL=postgresql+psycopg://arirang_user:change_me@localhost:5433/arirang
+POSTGRES_USER=replace_me
+POSTGRES_PASSWORD=replace_me
+DATABASE_URL=postgresql+psycopg://replace_me:replace_me@localhost:5433/arirang
+VITE_API_BASE_URL=

--- a/backend/fastapi/.dockerignore
+++ b/backend/fastapi/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+*.pyc
+.env
+.venv
+.pytest_cache

--- a/backend/fastapi/Dockerfile
+++ b/backend/fastapi/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app/backend/fastapi
+
+COPY backend/fastapi/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend/fastapi ./
+COPY content_data/data /app/content_data/data
+
+EXPOSE 8000
+
+CMD ["sh", "-c", "until python -c 'from database import engine; conn = engine.connect(); conn.close()'; do sleep 2; done; python seed.py; uvicorn main:app --host 0.0.0.0 --port 8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,42 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  backend:
+    build:
+      context: .
+      dockerfile: backend/fastapi/Dockerfile
+    container_name: arirang-backend
+    restart: always
+    environment:
+      DATABASE_URL: postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - default
+      - proxy-net
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-}
+    container_name: arirang-frontend
+    restart: always
+    depends_on:
+      - backend
+    networks:
+      - proxy-net
 
 volumes:
   postgres_data:
+
+networks:
+  proxy-net:
+    external: true

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+.gitignore
+Dockerfile
+.dockerignore
+npm-debug.log*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --legacy-peer-deps
+
+COPY . .
+
+ARG VITE_API_BASE_URL=
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+
+RUN npm run build
+
+FROM nginx:1.27-alpine
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,28 @@
+server {
+  listen 80;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+  client_max_body_size 25m;
+
+  location /api/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /assets/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -14,7 +14,23 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
-  location /assets/ {
+  location /assets/categories/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location /assets/cards/ {
+    proxy_pass http://backend:8000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location = /assets/tiger-snow.png {
     proxy_pass http://backend:8000;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## 요약

- Vite 프론트엔드를 Docker에서 빌드하고 Nginx로 정적 파일을 서빙하도록 구성
- 프론트 Nginx에 SPA fallback과 `/api/`, `/assets/` 백엔드 프록시 설정 추가
- FastAPI 백엔드 Dockerfile 추가
- 백엔드 컨테이너 시작 시 DB 연결 대기 후 `seed.py` 실행하도록 구성
- `docker-compose.yml`에 `backend`, `frontend`, Postgres healthcheck, `proxy-net` 연결 추가
- DB 계정/비밀번호를 `.env`로 분리하고 `.env.example`에는 placeholder만 유지

## 검증

- `docker compose config --quiet` 실행
- `docker compose up -d --build backend frontend` 실행
- `arirang-postgres` healthy 상태 확인
- `arirang-backend`, `arirang-frontend` 실행 상태 확인
- 백엔드 `seed.py` 정상 완료 확인
- 프론트 Nginx 경유 `/api/v1/categories` 호출이 백엔드로 정상 프록시되는 것 확인

## 참고

- 현재 구성에서는 프론트 Nginx가 `/api/`를 `backend:8000`으로 프록시하므로 `VITE_API_BASE_URL`은 빈 값으로 둡니다.
- Nginx Proxy Manager에서는 `arirang-frontend:80`으로 연결하면 됩니다.
- 로컬 `.env`는 git ignore 대상이며 커밋에 포함되지 않습니다.
