### PR TITLE
발음 피드백 품질 개선 및 ml_core 공개 API 정리

### DIFF
--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -616,7 +616,7 @@ async def evaluate_pronunciation(
             filename=audio_file.filename or f"{card_id}.webm",
             target_text=target_text,
         )
-        score, feedback = build_pronunciation_result(analysis)
+        score, feedback, heard_text, feedback_issues, next_practice_focus = build_pronunciation_result(analysis)
     except PronunciationAnalysisError as exc:
         return PronunciationResponse(
             success=False,
@@ -631,6 +631,9 @@ async def evaluate_pronunciation(
         card_id=card_id,
         score=score,
         feedback=feedback,
+        heard_text=heard_text,
+        feedback_issues=feedback_issues,
+        next_practice_focus=next_practice_focus,
         pronunciation_status="DONE",
         is_card_completed=True,
     )

--- a/backend/fastapi/pronunciation_client.py
+++ b/backend/fastapi/pronunciation_client.py
@@ -92,7 +92,10 @@ def build_pronunciation_result(analysis):
         raise PronunciationAnalysisError("ml_core 응답에 pronunciation_score.overall이 없습니다.")
 
     feedback = _extract_feedback(analysis)
-    return int(round(max(0, min(100, float(score))))), feedback
+    feedback_issues = _extract_feedback_issues(analysis)
+    practice_focus = _extract_next_practice_focus(analysis)
+    heard_text = _extract_heard_text(analysis)
+    return int(round(max(0, min(100, float(score))))), feedback, heard_text, feedback_issues, practice_focus
 
 
 def _extract_feedback(analysis):
@@ -100,20 +103,96 @@ def _extract_feedback(analysis):
     if llm_feedback.get("summary"):
         return llm_feedback["summary"]
 
-    diagnostics = analysis.get("diagnostic_candidates") or []
-    if diagnostics:
-        top = diagnostics[0]
-        target = top.get("target_unit")
-        rationale = top.get("rationale") or "발음에서 개선할 부분이 감지되었습니다."
-        if target:
-            return f"{target} 부분을 다시 연습해 보세요. {rationale}"
-        return rationale
+    issues = _extract_feedback_issues(analysis)
+    if issues:
+        issue = issues[0]
+        unit = issue.get("unit")
+        diagnosis = issue.get("diagnosis") or "발음에서 개선할 부분이 감지되었습니다."
+        if unit:
+            return f"{unit} 부분을 다시 연습해 보세요. {diagnosis}"
+        return diagnosis
 
     score = analysis.get("pronunciation_score", {})
     if score.get("note"):
         return score["note"]
 
     return "발음 분석이 완료되었습니다."
+
+
+def _extract_feedback_issues(analysis):
+    llm_feedback = analysis.get("llm_feedback") or {}
+    issues = llm_feedback.get("issues") or []
+    if issues:
+        return [_normalize_feedback_issue(issue) for issue in issues if isinstance(issue, dict)]
+
+    diagnostics = analysis.get("diagnostic_candidates") or []
+    return [_issue_from_diagnostic(item) for item in diagnostics[:3] if isinstance(item, dict)]
+
+
+def _normalize_feedback_issue(issue):
+    return {
+        "unit": issue.get("unit"),
+        "category": issue.get("category"),
+        "diagnosis": issue.get("diagnosis") or "발음에서 개선할 부분이 감지되었습니다.",
+        "evidence": issue.get("evidence"),
+        "coaching": issue.get("coaching"),
+        "confidence": issue.get("confidence"),
+    }
+
+
+def _issue_from_diagnostic(item):
+    target = item.get("target_unit")
+    rationale = item.get("rationale") or "발음에서 개선할 부분이 감지되었습니다."
+    if target:
+        coaching = f"{target} 소리를 정확히 내는 연습을 해보세요."
+    else:
+        coaching = "천천히 다시 녹음해서 발음 차이를 확인해 보세요."
+    return {
+        "unit": target,
+        "category": item.get("category"),
+        "diagnosis": rationale,
+        "evidence": item.get("diagnosis_code"),
+        "coaching": coaching,
+        "confidence": _confidence_label(item.get("confidence")),
+    }
+
+
+def _confidence_label(value):
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric >= 0.75:
+        return "high"
+    if numeric >= 0.45:
+        return "medium"
+    return "low"
+
+
+def _extract_heard_text(analysis):
+    predicted_text = analysis.get("predicted_text")
+    if isinstance(predicted_text, str) and predicted_text.strip():
+        return _readable_korean_jamo(predicted_text.strip())
+    predicted_phonemes = analysis.get("predicted_phonemes")
+    if isinstance(predicted_phonemes, str) and predicted_phonemes.strip():
+        return _readable_korean_jamo(predicted_phonemes.strip())
+    return None
+
+_KOREAN_VOWEL_TO_SYLLABLE = {
+    "ㅏ": "아", "ㅐ": "애", "ㅑ": "야", "ㅒ": "얘", "ㅓ": "어", "ㅔ": "에",
+    "ㅕ": "여", "ㅖ": "예", "ㅗ": "오", "ㅘ": "와", "ㅙ": "왜", "ㅚ": "외",
+    "ㅛ": "요", "ㅜ": "우", "ㅝ": "워", "ㅞ": "웨", "ㅟ": "위", "ㅠ": "유",
+    "ㅡ": "으", "ㅢ": "의", "ㅣ": "이",
+}
+
+
+def _readable_korean_jamo(value):
+    return "".join(_KOREAN_VOWEL_TO_SYLLABLE.get(char, char) for char in value)
+
+def _extract_next_practice_focus(analysis):
+    llm_feedback = analysis.get("llm_feedback") or {}
+    focus = llm_feedback.get("next_practice_focus") or []
+    return [item for item in focus if isinstance(item, str)][:3]
 
 
 def _extract_detail(response):

--- a/backend/fastapi/pronunciation_client.py
+++ b/backend/fastapi/pronunciation_client.py
@@ -13,6 +13,11 @@ PRONUNCIATION_ANALYSIS_ENDPOINT = os.getenv(
 PRONUNCIATION_ANALYSIS_TIMEOUT_SECONDS = float(
     os.getenv("BACKEND_PRONUNCIATION_ANALYSIS_TIMEOUT_SECONDS", "180")
 )
+NO_RECOGNIZABLE_SPEECH_MESSAGE = "음성에서 아무 텍스트도 감지되지 않았습니다. 다시 녹음해 주세요."
+NO_RECOGNIZABLE_SPEECH_MARKERS = (
+    "No recognizable speech was detected in the audio.",
+    "Predicted phoneme sequence is empty.",
+)
 
 
 class PronunciationAnalysisError(RuntimeError):
@@ -81,7 +86,7 @@ async def analyze_pronunciation(audio_bytes, filename, target_text):
             return response.json()
     except httpx.HTTPStatusError as exc:
         detail = _extract_detail(exc.response)
-        raise PronunciationAnalysisError(f"ml_core 발음 분석 실패: {detail}") from exc
+        raise PronunciationAnalysisError(_user_facing_error_message(detail)) from exc
     except httpx.HTTPError as exc:
         raise PronunciationAnalysisError(f"ml_core 발음 분석 서비스 연결 실패: {exc}") from exc
 
@@ -203,3 +208,10 @@ def _extract_detail(response):
     if isinstance(payload, dict) and "detail" in payload:
         return payload["detail"]
     return payload
+
+
+def _user_facing_error_message(detail):
+    detail_text = str(detail)
+    if any(marker in detail_text for marker in NO_RECOGNIZABLE_SPEECH_MARKERS):
+        return NO_RECOGNIZABLE_SPEECH_MESSAGE
+    return f"ml_core 발음 분석 실패: {detail_text}"

--- a/backend/fastapi/schemas.py
+++ b/backend/fastapi/schemas.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 # =============================================================================
@@ -172,6 +172,19 @@ class AnswerSubmitResponse(BaseModel):
     message: Optional[str] = None
 
 
+class PronunciationFeedbackIssue(BaseModel):
+    """
+    발음 피드백 상세 항목 모델
+    """
+
+    unit: Optional[str] = None
+    category: Optional[str] = None
+    diagnosis: str
+    evidence: Optional[str] = None
+    coaching: Optional[str] = None
+    confidence: Optional[str] = None
+
+
 class PronunciationResult(BaseModel):
     """
     발음 평가 결과 모델
@@ -180,6 +193,9 @@ class PronunciationResult(BaseModel):
     card_id: str
     score: int
     feedback: str
+    heard_text: Optional[str] = None
+    feedback_issues: List[PronunciationFeedbackIssue] = Field(default_factory=list)
+    next_practice_focus: List[str] = Field(default_factory=list)
     pronunciation_status: str
     is_card_completed: bool
 

--- a/frontend/src/pages/IngamePage/components/PronounceArea.jsx
+++ b/frontend/src/pages/IngamePage/components/PronounceArea.jsx
@@ -271,8 +271,14 @@ export default function PronounceArea({ cardId, targetText, ttsUrl, onFinish }) 
           <div className={styles.stepHeader}>
             “{targetText}”에 대한 발음 정확성
           </div>
-          <div className={styles.centerContentGap4}>
+          <div className={styles.resultContent}>
             <div className={styles.scoreText}>{result?.score ?? 0}점</div>
+            {result?.heard_text && (
+              <div className={styles.heardPanel}>
+                <span className={styles.heardLabel}>AI가 들은 발음</span>
+                <span className={styles.heardText}>“{result.heard_text}”</span>
+              </div>
+            )}
             <div className={styles.descText}>
               {result?.feedback || '분석 결과가 없습니다.'}
             </div>

--- a/frontend/src/pages/IngamePage/components/PronounceArea.module.css
+++ b/frontend/src/pages/IngamePage/components/PronounceArea.module.css
@@ -54,6 +54,17 @@
   gap: 1rem;
 }
 
+.resultContent {
+  align-self: stretch;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  gap: 0.7rem;
+}
+
 .aiLoadingBar {
   width: 14rem;
   height: 12px;
@@ -110,6 +121,36 @@
   font-family: var(--font-sans);
   line-height: 1.25;
   user-select: text;
+}
+
+.heardPanel {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.45rem 0.65rem;
+  border: var(--spacing-border-main) solid var(--color-text);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.38);
+}
+
+.heardLabel {
+  color: var(--color-text-dimmed, #7D7D7D);
+  font-size: 0.72rem;
+  font-weight: var(--font-weight-semibold);
+  font-family: var(--font-sans);
+}
+
+.heardText {
+  max-width: 100%;
+  color: var(--color-text);
+  font-size: 1rem;
+  font-weight: var(--font-weight-bold);
+  font-family: var(--font-sans);
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .waveformContainer {

--- a/ml_core/README.md
+++ b/ml_core/README.md
@@ -64,14 +64,6 @@ docker compose up --build
 curl http://localhost:8000/health
 ```
 
-예측 요청:
-
-```powershell
-curl -X POST http://localhost:8000/predict `
-  -F "script=옷을 입어요" `
-  -F "audio=@.\sample.wav"
-```
-
 발음 분석 요청:
 
 ```powershell

--- a/ml_core/app/acoustic_analysis.py
+++ b/ml_core/app/acoustic_analysis.py
@@ -138,6 +138,7 @@ class AcousticAnalyzer:
         )
         response = PronunciationAnalysisResponse(
             script=prediction.script,
+            predicted_text=prediction.predicted_text,
             canonical_phonemes=prediction.canonical_phonemes,
             predicted_phonemes=prediction.predicted_phonemes,
             pronunciation_score=pronunciation_score,

--- a/ml_core/app/acoustic_analysis.py
+++ b/ml_core/app/acoustic_analysis.py
@@ -208,8 +208,6 @@ class AcousticAnalyzer:
             ratio = prosody.speech_duration_ratio
             if ratio > 1.15:
                 score -= min(35.0, (ratio - 1.15) * 22.0)
-            elif ratio < 0.75:
-                score -= min(25.0, (0.75 - ratio) * 30.0)
         score -= min(25.0, prosody.interior_pause_total_ms / 160.0)
         score -= min(15.0, len(prosody.stretched_intervals) * 4.0)
         if prosody.rate_reliability == "low":

--- a/ml_core/app/acoustic_analysis.py
+++ b/ml_core/app/acoustic_analysis.py
@@ -217,11 +217,11 @@ class AcousticAnalyzer:
 
     @staticmethod
     def _audio_quality_score(quality: AudioQualitySummary) -> float:
-        base = {"high": 100.0, "medium": 82.0, "low": 60.0}[quality.overall_reliability]
+        base = {"high": 100.0, "medium": 92.0, "low": 75.0}[quality.overall_reliability]
         if quality.clipping_detected:
-            base -= 15.0
-        if quality.snr_db is not None and quality.snr_db < 12.0:
-            base -= min(20.0, (12.0 - quality.snr_db) * 2.0)
+            base -= 8.0
+        if quality.snr_db is not None and quality.snr_db < 6.0:
+            base -= min(15.0, (6.0 - quality.snr_db) * 2.0)
         return max(0.0, min(100.0, base))
 
     @classmethod
@@ -322,7 +322,8 @@ class AcousticAnalyzer:
         if len(audio.samples) == 0:
             return AudioQualitySummary(overall_reliability="low")
         peak = float(np.max(np.abs(audio.samples)))
-        clipping_detected = peak >= 0.999
+        clipped_ratio = float(np.mean(np.abs(audio.samples) >= 0.999))
+        clipping_detected = peak >= 0.999 and clipped_ratio >= 0.01
         rms = float(np.sqrt(np.mean(np.square(audio.samples)) + 1e-9))
         tail = audio.samples[-min(len(audio.samples), audio.sample_rate // 3 or 1) :]
         noise_floor = float(np.sqrt(np.mean(np.square(tail)) + 1e-9))
@@ -330,9 +331,9 @@ class AcousticAnalyzer:
         zero_cross = np.mean(np.abs(np.diff(np.signbit(audio.samples))).astype(np.float32))
         voiced_ratio = max(0.0, min(1.0, 1.0 - float(zero_cross)))
         reliability = "high"
-        if clipping_detected or snr_db < 12.0:
+        if snr_db < 6.0:
             reliability = "low"
-        elif snr_db < 20.0:
+        elif clipping_detected or snr_db < 12.0:
             reliability = "medium"
         return AudioQualitySummary(
             snr_db=round(snr_db, 2),

--- a/ml_core/app/acoustic_schemas.py
+++ b/ml_core/app/acoustic_schemas.py
@@ -165,6 +165,7 @@ class PronunciationScore(BaseModel):
 
 class PronunciationAnalysisResponse(BaseModel):
     script: str
+    predicted_text: Optional[str] = None
     canonical_phonemes: str
     predicted_phonemes: str
     pronunciation_score: PronunciationScore

--- a/ml_core/app/gemini_client.py
+++ b/ml_core/app/gemini_client.py
@@ -54,55 +54,57 @@ class GeminiFeedbackClient:
 
     @staticmethod
     def _build_prompt(evidence: AcousticEvidencePacket) -> str:
-        evidence_json = evidence.model_dump_json(exclude_none=True, indent=2)
+        evidence_json = json.dumps(
+            GeminiFeedbackClient._compact_evidence(evidence),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
         feedback_language = evidence.policy.language
         instructions = {
-            "task": "Generate learner-facing Korean pronunciation feedback from structured phonetic evidence.",
+            "task": "Generate short learner-facing Korean pronunciation feedback from structured evidence.",
             "response_language": feedback_language,
-            "scope": [
-                "Use script/canonical_text and predicted_text as the main utterance-level comparison.",
-                "Use canonical_phonemes and predicted_phonemes to judge global phoneme-sequence similarity.",
-                "If the predicted utterance is substantially different from the target, prioritize that over small local corrections.",
-                "Use MDD phoneme mismatches as supporting evidence for local pronunciation errors.",
-                "Use phoneme_edits as a local mismatch summary and supporting detail.",
-                "If phoneme_edits shows one deletion or insertion, do not describe later aligned sounds as a cascade of substitutions.",
-                "When the same phoneme appears multiple times, use phoneme_edits.expected_index, syllable, and context to identify the occurrence.",
-                "Use acoustic measurements only as secondary context when they are explicitly supplied.",
-                "Do not create specific local pronunciation errors beyond the supplied phoneme_edits and diagnostic_candidates.",
-            ],
             "requirements": [
                 "Use only the supplied evidence.",
-                "Do not infer hidden measurements.",
-                "Treat the full target/predicted utterance comparison as primary evidence.",
-                "Treat MDD phoneme mismatch and phoneme edit alignment as supporting evidence for specific local issues.",
-                "predicted_text and predicted_phonemes are model-decoded pronunciation evidence, not a guaranteed literal transcript.",
-                "If canonical_text and predicted_text differ substantially, say the target sentence was pronounced very differently before giving local phoneme coaching.",
-                "For foreign-accent feedback, describe the likely Korean listener perception, not medical or native-speaker claims.",
-                "The learner may be a non-native Korean speaker; do not push native-speed delivery.",
-                "If a long interior pause is present, describe the issue as pause/connection timing rather than general slow speech.",
-                "For prosodic timing, frame coaching as smoother connection and intelligibility, not speaking as fast as the TTS reference.",
-                "If diagnosis_code is stretched_aligned_unit, describe the target unit as held or stretched too long.",
-                "For stretched_aligned_unit, set issue.unit to the diagnostic target_unit when it is present.",
-                "Do not convert stretched_aligned_unit into a pause issue unless a reference_pause_comparison with pause_level medium or high is present.",
-                "Reference pause comparisons may include pause_level medium or high.",
-                "If pause_level is medium, describe it as a noticeable pause between words.",
-                "If pause_level is high, prioritize it as a main prosodic issue.",
-                "Do not describe medium pause_level as globally slow speech.",
-                "If alignment source is heuristic or audio reliability is low, lower the confidence.",
-                "If reliability is low, mention that uncertainty briefly.",
-                "Prioritize the top 1-3 issues.",
-                "If diagnostic_candidates is not empty, issues must contain at least one issue grounded in those diagnostics.",
-                "issue.diagnosis must be a short learner-facing phrase, not a diagnostic code.",
-                "Never copy snake_case values such as diagnosis_code into learner-facing fields.",
-                "Coaching should be short, concrete, and pronounceable by a learner.",
-                "For segmental issues, issue.unit must come from phoneme_edits.expected or phoneme_edits.actual.",
-                "For prosodic issues such as slow speech rate or long pauses, issue.unit may be null.",
-                f"Write all learner-facing text in this language code or language name: {feedback_language}.",
+                "Base issues on diagnostic_candidates and phoneme_edits.",
+                "Do not copy snake_case diagnosis codes into learner-facing fields.",
+                "Return 1-3 concise issues with concrete coaching.",
+                f"Write learner-facing text in {feedback_language}.",
             ],
         }
         return (
             "You are a Korean pronunciation coach.\n"
             "Return JSON only and follow the provided schema.\n"
-            f"Instruction:\n{json.dumps(instructions, ensure_ascii=False, indent=2)}\n"
+            f"Instruction:\n{json.dumps(instructions, ensure_ascii=False, separators=(',', ':'))}\n"
             f"Evidence:\n{evidence_json}"
         )
+
+    @staticmethod
+    def _compact_evidence(evidence: AcousticEvidencePacket) -> dict:
+        payload = {
+            "target_text": evidence.script,
+            "predicted_text": evidence.predicted_text,
+            "target_phonemes": evidence.canonical_phonemes,
+            "predicted_phonemes": evidence.predicted_phonemes,
+            "phoneme_edits": [
+                edit.model_dump(exclude_none=True)
+                for edit in evidence.phoneme_edits[:3]
+            ],
+            "diagnostic_candidates": [
+                item.model_dump(exclude_none=True)
+                for item in evidence.diagnostic_candidates[:3]
+            ],
+            "feedback_language": evidence.policy.language,
+        }
+        if evidence.audio_quality.overall_reliability != "high":
+            payload["audio_quality"] = evidence.audio_quality.model_dump(exclude_none=True)
+        if evidence.prosody is not None:
+            payload["prosody"] = evidence.prosody.model_dump(
+                exclude_none=True,
+                exclude={
+                    "pause_intervals",
+                    "stretched_intervals",
+                    "reference_duration_comparisons",
+                    "reference_pause_comparisons",
+                },
+            )
+        return {key: value for key, value in payload.items() if value not in (None, [], {})}

--- a/ml_core/app/gemini_client.py
+++ b/ml_core/app/gemini_client.py
@@ -66,6 +66,8 @@ class GeminiFeedbackClient:
             "requirements": [
                 "Use only the supplied evidence.",
                 "Base issues on diagnostic_candidates and phoneme_edits.",
+                "For each issue, diagnosis must name what was wrong, such as the extra, missing, substituted, stretched, or paused sound.",
+                "For each issue, evidence must compare the target pronunciation with what was heard or decoded.",
                 "Do not copy snake_case diagnosis codes into learner-facing fields.",
                 "Return 1-3 concise issues with concrete coaching.",
                 f"Write learner-facing text in {feedback_language}.",

--- a/ml_core/app/server.py
+++ b/ml_core/app/server.py
@@ -13,7 +13,7 @@ from app.gemini_client import GeminiFeedbackClient
 from app.inference_client import InferenceClient
 from app.pronunciation_analysis_service import PronunciationAnalysisService
 from app.reference_cache import ReferenceCacheManifest, ReferenceCacheRequest, create_reference_cache_store
-from app.schemas import HealthResponse, PredictResponse
+from app.schemas import HealthResponse
 from app.tts_asset_cache import TTSAssetManifest, TTSAssetRequest, create_tts_asset_store
 from app.tts_reference import EdgeTTSReferenceGenerator, create_tts_reference_generator
 
@@ -83,89 +83,6 @@ def healthcheck() -> HealthResponse:
         tts_provider=settings.tts_provider,
         tts_voice_id=settings.tts_voice_id,
     )
-
-
-@app.post("/predict", response_model=PredictResponse, response_model_exclude_none=True)
-async def predict(
-    script: str = Form(...),
-    audio: UploadFile = File(...),
-) -> PredictResponse:
-    try:
-        payload = await audio.read()
-        return client.predict(payload, audio.filename or "input.wav", script)
-    except httpx.HTTPStatusError as exc:
-        raise HTTPException(status_code=exc.response.status_code, detail=_extract_upstream_detail(exc)) from exc
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"inference service unavailable: {exc}") from exc
-
-
-@app.get(
-    "/reference-cache/{cache_key}",
-    response_model=ReferenceCacheManifest,
-    response_model_exclude_none=True,
-)
-def get_reference_cache_manifest(cache_key: str) -> ReferenceCacheManifest:
-    manifest = reference_cache.get_manifest(cache_key)
-    if manifest is None:
-        raise HTTPException(status_code=404, detail="reference cache entry not found")
-    return manifest
-
-
-@app.post(
-    "/reference-cache",
-    response_model=ReferenceCacheManifest,
-    response_model_exclude_none=True,
-)
-async def put_reference_cache(
-    script: str = Form(...),
-    alignment_json: str = Form(...),
-    language: str = Form("Korean"),
-    tts_provider: str = Form("unknown"),
-    tts_model: str = Form("unknown"),
-    voice_id: str = Form("default"),
-    speaking_rate: float = Form(1.0),
-    audio_format: str = Form("wav_16khz_mono"),
-    aligner_model_id: str = Form("Qwen/Qwen3-ForcedAligner-0.6B"),
-    alignment_resolution_ms: int = Form(80),
-    audio: UploadFile = File(...),
-) -> ReferenceCacheManifest:
-    try:
-        alignment = ForcedAlignmentResponse.model_validate_json(alignment_json)
-        request = ReferenceCacheRequest(
-            script=script,
-            language=language,
-            tts_provider=tts_provider,
-            tts_model=tts_model,
-            voice_id=voice_id,
-            speaking_rate=speaking_rate,
-            audio_format=audio_format,
-            aligner_model_id=aligner_model_id,
-            alignment_resolution_ms=alignment_resolution_ms,
-        )
-        return reference_cache.put_reference(request, await audio.read(), alignment)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-
-
-@app.post(
-    "/reference-cache/generate",
-    response_model=ReferenceCacheManifest,
-    response_model_exclude_none=True,
-)
-def generate_reference_cache(
-    script: str = Form(...),
-    language: str | None = Form(None),
-) -> ReferenceCacheManifest:
-    try:
-        return _get_or_create_tts_reference(script, language)
-    except httpx.HTTPStatusError as exc:
-        raise HTTPException(status_code=exc.response.status_code, detail=_extract_upstream_detail(exc)) from exc
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=502, detail=f"aligner service unavailable: {exc}") from exc
-    except RuntimeError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
 @app.get(

--- a/ml_core/docs/acoustic-analysis-implementation-status.md
+++ b/ml_core/docs/acoustic-analysis-implementation-status.md
@@ -41,11 +41,15 @@ It is separate from the design document and focuses on current behavior, validat
 - `aligner`
   - `Qwen/Qwen3-ForcedAligner-0.6B`
 
-## Implemented Endpoints
+## Implemented Public Endpoints
 
 - `GET /health`
-- `POST /predict`
 - `POST /analyze-pronunciation-llm`
+- `GET /tts-assets/{cache_key}`
+- `GET /tts-assets/{cache_key}/audio`
+- `POST /tts-assets/generate`
+
+The inference service still keeps its internal `POST /predict` endpoint for API-to-inference calls.
 
 ## Implemented Error Handling
 

--- a/ml_core/docs/pronunciation-analysis-api-fields.md
+++ b/ml_core/docs/pronunciation-analysis-api-fields.md
@@ -1,11 +1,6 @@
 # Pronunciation Analysis API Fields
 
-This document explains the response fields for:
-
-- `POST /analyze-pronunciation-llm`
-- `POST /reference-cache`
-- `POST /reference-cache/generate`
-- `GET /reference-cache/{cache_key}`
+This document explains the response fields for `POST /analyze-pronunciation-llm`.
 
 By default, the analysis endpoint returns a compact response. Pass `debug=true` to include full alignments and phoneme scores.
 
@@ -23,37 +18,9 @@ By default, the analysis endpoint returns a compact response. Pass `debug=true` 
 
 ## Reference Cache
 
-The reference cache stores TTS-generated answer audio and its Qwen forced alignment result in object storage. In Docker Compose this uses MinIO.
+The reference cache stores TTS-generated answer audio and its Qwen forced alignment result in object storage. In Docker Compose this uses MinIO. It is an internal implementation detail of `POST /analyze-pronunciation-llm`, not a public API surface.
 
-`POST /reference-cache` accepts:
-
-| Field | Required | Default | Description |
-| --- | --- | --- | --- |
-| `script` | yes | - | Target script used to generate the TTS reference. |
-| `audio` | yes | - | TTS reference audio, normally normalized WAV. |
-| `alignment_json` | yes | - | Qwen forced alignment response JSON for the TTS reference audio. |
-| `language` | no | `Korean` | Alignment language. |
-| `tts_provider` | no | `unknown` | TTS provider name. |
-| `tts_model` | no | `unknown` | TTS model or engine version. |
-| `voice_id` | no | `default` | TTS voice identifier. |
-| `speaking_rate` | no | `1.0` | TTS speaking rate used when generating the reference. |
-| `audio_format` | no | `wav_16khz_mono` | Normalized audio format. |
-| `aligner_model_id` | no | `Qwen/Qwen3-ForcedAligner-0.6B` | Aligner model used to create `alignment_json`. |
-| `alignment_resolution_ms` | no | `80` | Aligner timestamp resolution. |
-
-The cache key is a SHA-256 hash over normalized script, language, TTS provider/model/voice/rate, audio format, aligner model, aligner resolution, and cache schema version.
-
-Objects are stored as:
-
-```text
-tts-reference/{cache_key}/reference.wav
-tts-reference/{cache_key}/alignment.json
-tts-reference/{cache_key}/manifest.json
-```
-
-`GET /reference-cache/{cache_key}` returns the manifest if the cache entry exists.
-
-`POST /reference-cache/generate` accepts `script` and optional `language`. It generates a TTS reference audio file, runs Qwen forced alignment for that TTS audio, stores both objects in MinIO, and returns the manifest. The analysis endpoints call this path automatically when `use_tts_reference=true` and no `reference_cache_key` was supplied, or when the supplied key is not found.
+When `use_tts_reference=true`, the analysis endpoint creates or reuses a reference entry automatically and compares learner timing against the cached alignment.
 
 ## Top-Level Response Fields
 


### PR DESCRIPTION
## 변경 사항

- 발음 분석 응답에 heard_text, 상세 피드백 항목, 다음 연습 포커스를 추가했습니다.
- 프론트 발음 결과 화면에 “AI가 들은 발음” 영역을 표시하도록 개선했습니다.
- 짧은 발화나 낮은 음질 판정이 과도하게 점수 하락으로 이어지지 않도록 scoring threshold를 조정했습니다.
- Gemini 피드백 프롬프트를 압축해 LLM 호출 지연과 불필요한 evidence 전달을 줄였습니다.
- 사용하지 않는 ml_core gateway 공개 API를 제거했습니다.
    - POST /predict
    - GET /reference-cache/{cache_key}
    - POST /reference-cache
    - POST /reference-cache/generate

- 내부 inference 서비스의 POST /predict와 reference cache 내부 흐름은 유지했습니다.
- ml_core README와 API 문서를 현재 공개 엔드포인트 기준으로 정리했습니다.

## 확인 사항

- python3 -m py_compile ml_core/app/server.py
- git diff --check

## 참고

현재 브랜치: test/pronunciation-llm-latency

main 대비 주요 커밋:

- 발음 피드백 지연 및 품질 threshold 조정
- AI가 들은 발음 표시
- 짧은 발음 점수 하락 완화
- 사용하지 않는 ml_core 공개 엔드포인트 제거
