### PR TITLE
fix: 문장 이미지 및 최근 기록 카드 연결

### DIFF
--- a/backend/fastapi/Dockerfile
+++ b/backend/fastapi/Dockerfile
@@ -14,6 +14,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/fastapi ./
 COPY content_data/data /app/content_data/data
+COPY frontend/public/sentence_images /app/frontend/public/sentence_images
 
 EXPOSE 8000
 

--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -259,40 +259,19 @@ def get_recent_cards_from_db(db: Session):
     )
 
     if records:
-        recent_cards = []
-        seen_words = set()
-
-        for record in records:
-            word = record.quiz.polysemy_word
-            if word in seen_words:
-                continue
-
-            seen_words.add(word)
-            recent_cards.append(
+        return [
                 RecentCard(
                     card_id=record.quiz.card_id,
                     set_id=record.quiz.set_id,
-                    word=word,
+                    word=record.quiz.polysemy_word,
                     image_url=record.quiz.image_url or CARD_IMAGE_PLACEHOLDER,
                     last_viewed_at=record.last_viewed_at.isoformat(),
                 )
-            )
-
-            if len(recent_cards) >= 6:
-                break
-
-        return recent_cards
+            for record in records
+        ]
 
     quizzes = db.query(QuizDB).order_by(QuizDB.card_id).limit(6).all()
-    recent_cards = []
-    seen_words = set()
-
-    for quiz in quizzes:
-        if quiz.polysemy_word in seen_words:
-            continue
-
-        seen_words.add(quiz.polysemy_word)
-        recent_cards.append(
+    return [
             RecentCard(
                 card_id=quiz.card_id,
                 set_id=quiz.set_id,
@@ -300,9 +279,8 @@ def get_recent_cards_from_db(db: Session):
                 image_url=quiz.image_url or CARD_IMAGE_PLACEHOLDER,
                 last_viewed_at=datetime.now(timezone.utc).isoformat(),
             )
-        )
-
-    return recent_cards
+        for quiz in quizzes
+    ]
 
 
 # =============================================================================

--- a/backend/fastapi/seed.py
+++ b/backend/fastapi/seed.py
@@ -17,6 +17,7 @@ from tts_client import generate_tts_url
 
 BASE_DIR = Path(__file__).resolve().parents[2]
 DATA_DIR = BASE_DIR / "content_data" / "data"
+SENTENCE_IMAGE_DIR = BASE_DIR / "frontend" / "public" / "sentence_images"
 
 CATEGORY_INFO = {
     "school": {"name_ko": "고등학교", "name_en": "High school"},
@@ -70,6 +71,17 @@ WORD_IMAGE_MAPPING = {
     "쓰다": "/assets/cards/bird-write.png",
     "눈": "/assets/cards/placeholder.png",
 }
+
+SENTENCE_IMAGE_BASE_URL = "/sentence_images"
+
+
+def build_sentence_image_url(sentence_id):
+    if not sentence_id:
+        return None
+    image_path = SENTENCE_IMAGE_DIR / f"{sentence_id}.png"
+    if not image_path.exists():
+        return None
+    return f"{SENTENCE_IMAGE_BASE_URL}/{sentence_id}.png"
 
 
 def load_json(filename):
@@ -278,7 +290,8 @@ def build_quizzes_from_sentences(meanings, sentences, quiz_overrides):
                 "correct_choice_id": "c1",
                 "pronunciation_target": pronunciation_target,
                 "tts_url": correct_pool[0].get("tts_url"),
-                "image_url": override.get("image_url")
+                "image_url": build_sentence_image_url(prompt_id)
+                or override.get("image_url")
                 or WORD_IMAGE_MAPPING.get(word, "/assets/cards/placeholder.png"),
                 "card_order": card_order_by_set[set_id],
                 "set_id": set_id,

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -35,6 +35,7 @@ const resolveFrontendAsset = (url) => {
 
 export const resolveAssetUrl = (url) => {
   if (!url) return ''
+  if (url.startsWith('/sentence_images/')) return url
   const frontendAsset = resolveFrontendAsset(url)
   if (frontendAsset) return frontendAsset
   if (/^https?:\/\//.test(url)) return url

--- a/frontend/src/pages/HomePage/index.jsx
+++ b/frontend/src/pages/HomePage/index.jsx
@@ -118,7 +118,10 @@ function HomePage() {
             id: item.card_id,
             title: item.word,
             image: resolveAssetUrl(item.image_url),
-            onClick: () => handleTransition(`/ingame/${item.set_id}`, 'var(--color-yellow-primary)'),
+            onClick: () => handleTransition(
+              `/ingame/${item.set_id}?card=${encodeURIComponent(item.card_id)}`,
+              'var(--color-yellow-primary)'
+            ),
           }))
         )
       } catch (error) {

--- a/frontend/src/pages/IngamePage/index.jsx
+++ b/frontend/src/pages/IngamePage/index.jsx
@@ -13,6 +13,7 @@ export default function IngamePage() {
   const { setId } = useParams()
   const [searchParams] = useSearchParams()
   const selectedWord = searchParams.get('word') || ''
+  const selectedCardId = searchParams.get('card') || ''
 
   const [currentStep] = useState('quiz')
   const [isStageUnlocked, setIsStageUnlocked] = useState(false)
@@ -47,7 +48,9 @@ export default function IngamePage() {
       try {
         setIsLoading(true)
         const data = await getSetCards(setId)
-        const filteredCards = selectedWord
+        const filteredCards = selectedCardId
+          ? data.cards.filter((card) => card.card_id === selectedCardId)
+          : selectedWord
           ? data.cards.filter((card) => card.polysemy_word === selectedWord)
           : data.cards
 
@@ -78,7 +81,7 @@ export default function IngamePage() {
     return () => {
       isMounted = false
     }
-  }, [setId, selectedWord])
+  }, [setId, selectedWord, selectedCardId])
 
   const handleBack = () => {
     setIsExiting(true)


### PR DESCRIPTION
## 작업 내역
- [x] 문장 ID 기반으로 카드 이미지가 `frontend/public/sentence_images` 이미지를 사용하도록 수정
- [x] 최근 기록을 단어가 아닌 카드 단위로 노출하고, 클릭 시 해당 카드로 진입하도록 수정
- [x] 프론트에서 `/sentence_images/...` 경로를 public asset으로 그대로 처리하도록 수정

## 관련된 이슈
- resolves #

## 리뷰어에게 할 말 (선택)
- `docker-compose.yml` 변경은 PR에서 제외했습니다.
- 로컬에서 DB seed 후 API 응답의 모든 카드 이미지가 `/sentence_images/{sentence_id}.png`로 내려오는 것 확인했습니다.

## 체크리스트
- [x] 코드가 정상적으로 빌드 및 실행됨.
- [x] 불필요한 `console.log`나 주석을 제거함.
- [x] 민감한 환경변수(API 키 등)가 코드에 포함되지 않음.