### PR TITLE
fix: 발음 분석 서비스 미연결 fallback 처리

### DIFF
--- a/backend/fastapi/main.py
+++ b/backend/fastapi/main.py
@@ -60,6 +60,7 @@ from db_models import (
 )
 from pronunciation_client import (
     PronunciationAnalysisError,
+    PronunciationServiceUnavailableError,
     analyze_pronunciation,
     build_pronunciation_result,
 )
@@ -549,6 +550,25 @@ async def submit_card_answer(
 # =============================================================================
 
 
+def build_pronunciation_fallback_result(card_id: str):
+    return PronunciationResult(
+        card_id=card_id,
+        score=0,
+        feedback=(
+            "발음 분석 서비스가 준비되지 않아 점수 평가를 건너뛰었습니다. "
+            "녹음은 완료되었으니 다음 문장으로 이어서 연습해 주세요."
+        ),
+        heard_text=None,
+        display_pronunciation_status="분석 서비스 준비 중",
+        raw_heard_text=None,
+        raw_predicted_phonemes=None,
+        feedback_issues=[],
+        next_practice_focus=["발음 분석 서비스가 연결되면 다시 평가해 보세요."],
+        pronunciation_status="UNAVAILABLE",
+        is_card_completed=True,
+    )
+
+
 @app.post("/api/v1/cards/{card_id}/pronunciation", response_model=PronunciationResponse)
 async def evaluate_pronunciation(
     card_id: str,
@@ -604,6 +624,14 @@ async def evaluate_pronunciation(
             feedback_issues,
             next_practice_focus,
         ) = build_pronunciation_result(analysis)
+    except PronunciationServiceUnavailableError:
+        touch_recent_learning_record(db, card_id)
+        db.commit()
+        return PronunciationResponse(
+            success=True,
+            data=build_pronunciation_fallback_result(card_id),
+            message=None,
+        )
     except PronunciationAnalysisError as exc:
         return PronunciationResponse(
             success=False,

--- a/backend/fastapi/pronunciation_client.py
+++ b/backend/fastapi/pronunciation_client.py
@@ -24,6 +24,10 @@ class PronunciationAnalysisError(RuntimeError):
     pass
 
 
+class PronunciationServiceUnavailableError(PronunciationAnalysisError):
+    pass
+
+
 def _convert_webm_to_wav(webm_bytes: bytes) -> bytes:
     with tempfile.NamedTemporaryFile(suffix=".webm", delete=False) as f_in:
         f_in.write(webm_bytes)
@@ -51,7 +55,9 @@ def _convert_webm_to_wav(webm_bytes: bytes) -> bytes:
 
 async def analyze_pronunciation(audio_bytes, filename, target_text):
     if not MDD_API_BASE_URL:
-        raise PronunciationAnalysisError("MDD_API_BASE_URL 환경변수가 설정되어 있지 않습니다.")
+        raise PronunciationServiceUnavailableError(
+            "발음 분석 서비스가 아직 연결되지 않았습니다."
+        )
 
     endpoint = PRONUNCIATION_ANALYSIS_ENDPOINT
     if not endpoint.startswith("/"):
@@ -88,7 +94,9 @@ async def analyze_pronunciation(audio_bytes, filename, target_text):
         detail = _extract_detail(exc.response)
         raise PronunciationAnalysisError(_user_facing_error_message(detail)) from exc
     except httpx.HTTPError as exc:
-        raise PronunciationAnalysisError(f"ml_core 발음 분석 서비스 연결 실패: {exc}") from exc
+        raise PronunciationServiceUnavailableError(
+            "발음 분석 서비스가 아직 연결되지 않았습니다."
+        ) from exc
 
 
 def build_pronunciation_result(analysis):


### PR DESCRIPTION
## 작업 내역
- [x] ML 발음 분석 서비스 미연결 시 내부 환경변수 에러가 노출되지 않도록 fallback 처리
- [x] 발음 분석 서비스 연결 실패 시 사용자용 fallback 응답 반환
- [x] fallback 상태에서도 카드 완료/최근 기록 흐름이 이어지도록 처리

## 관련된 이슈
- resolves #

## 리뷰어에게 할 말 (선택)
- 프론트 UI 표현은 프론트 쪽에서 별도 처리 예정이라 백엔드 응답 처리만 수정했습니다.
- `MDD_API_BASE_URL` 미설정 또는 ML API 연결 실패 시 `pronunciation_status: "UNAVAILABLE"` 상태로 응답합니다.

## 체크리스트
- [x] 코드가 정상적으로 빌드 및 실행됨.
- [x] 불필요한 `console.log`나 주석을 제거함.
- [x] 민감한 환경변수(API 키 등)가 코드에 포함되지 않음.